### PR TITLE
Improve time complexity of Tube initialization

### DIFF
--- a/src/core/dynamics/tube/tubex_Tube.cpp
+++ b/src/core/dynamics/tube/tubex_Tube.cpp
@@ -108,7 +108,7 @@ namespace tubex
 
       for(int i = 0 ; i < v_domains.size() ; i++)
       {
-        sample(s, v_domains[i].ub());
+        sample(v_domains[i].ub(), s);
         s->set_envelope(v_codomains[i]);
         s = s->next_slice();
       }

--- a/src/core/dynamics/tube/tubex_Tube.cpp
+++ b/src/core/dynamics/tube/tubex_Tube.cpp
@@ -108,7 +108,7 @@ namespace tubex
 
       for(int i = 0 ; i < v_domains.size() ; i++)
       {
-        sample(v_domains[i].ub());
+        sample(s, v_domains[i].ub());
         s->set_envelope(v_codomains[i]);
         s = s->next_slice();
       }
@@ -443,11 +443,10 @@ namespace tubex
       return i;
     }
 
-    void Tube::sample(double t)
+    void Tube::sample(double t, Slice *slice_to_be_sampled)
     {
-      assert(domain().contains(t));
+      assert(slice_to_be_sampled->domain().contains(t));
 
-      Slice *slice_to_be_sampled = slice(t);
       if(slice_to_be_sampled->domain().lb() == t || slice_to_be_sampled->domain().ub() == t)
       {
         // No degenerate slice,
@@ -473,6 +472,14 @@ namespace tubex
         Slice::chain_slices(slice_to_be_sampled, new_slice);
         new_slice->set_input_gate(new_slice->codomain());
       }
+    }
+
+    void Tube::sample(double t)
+    {
+      assert(domain().contains(t));
+
+      Slice *slice_to_be_sampled = slice(t);
+      sample(t, slice_to_be_sampled);
     }
 
     void Tube::sample(double t, const Interval& gate)

--- a/src/core/dynamics/tube/tubex_Tube.h
+++ b/src/core/dynamics/tube/tubex_Tube.h
@@ -353,7 +353,19 @@ namespace tubex
        *
        * \param t the temporal key (double, must belong to the Tube domain)
        */
+
       void sample(double t);
+
+      /**
+       * \brief Samples the given Slice of this tube at \f$t\f$
+       *
+       * \note Without any effect if two Slice objects are already defined at \f$t\f$
+       *       (if the gate \f$[x](t)\f$ already exists)
+       *
+       * \param t the temporal key (double, must belong to the Tube domain)
+       * \param slice_to_be_sampled a pointer to the Slice whose domain contains t
+       */
+      void sample(double t, Slice *slice_to_be_sampled);
 
       /**
        * \brief Samples this tube at \f$t\f$ with a specific gate value


### PR DESCRIPTION
... from a vector of domains and a vector of codomains.

To do this, I added a new sample method that expects a pointer to the Slice to be sampled.