### PR TITLE
new Tube and TubeVector methods useful for solver and correction of 2 bugs

### DIFF
--- a/src/core/dynamics/tube/tubex_Tube.cpp
+++ b/src/core/dynamics/tube/tubex_Tube.cpp
@@ -441,6 +441,30 @@ namespace tubex
       return largest;
     }
     
+  Slice* Tube::steepest_slice()
+    {
+      return const_cast<Slice*>(static_cast<const Tube&>(*this).steepest_slice());
+    }
+
+  const Slice* Tube::steepest_slice() const
+    {
+      double max_dif = 0.;
+      const Slice *steepest_slice;
+      steepest_slice=first_slice();
+      for(const Slice *s = first_slice() ; s != NULL ; s = s->next_slice()){
+	double dif = fabs (s->output_gate().mid() - s->input_gate().mid());
+        if( dif > max_dif)
+	  {
+	    steepest_slice = s;
+	    max_dif = dif;
+	  }
+      }
+      return steepest_slice;
+    }
+
+
+
+
     const Interval Tube::slice_domain(int slice_id) const
     {
       assert(slice_id >= 0 && slice_id < nb_slices());

--- a/src/core/dynamics/tube/tubex_Tube.h
+++ b/src/core/dynamics/tube/tubex_Tube.h
@@ -322,6 +322,21 @@ namespace tubex
        */
       const Slice* largest_slice() const;
 
+ /**
+       * \brief Returns a pointer to the Slice object of this tube for which
+       *        the difference between the input and outout gate midvalue is the largest
+       *
+       * \return a pointer to the corresponding Slice
+       */
+      Slice* steepest_slice();
+       /**
+       * \brief Returns a const pointer to the Slice object of this tube for which
+       *        the difference between the input and outout gate midvalue is the largest
+       *
+       * \return a const pointer to the corresponding Slice
+       */
+      const Slice* steepest_slice() const;
+
       /**
        * \brief Returns the temporal definition domain of the ith Slice of this tube
        *
@@ -525,14 +540,14 @@ namespace tubex
       void invert(const ibex::Interval& y, std::vector<ibex::Interval> &v_t, const Tube& v, const ibex::Interval& search_domain = ibex::Interval::ALL_REALS) const;
       
       /**
-       * \brief Returns the diameter of the interval value \f$[x](t)\f$ that is the more uncertain
+       * \brief Returns the diameter of the interval value \f$[x](t)\f$ that is the most uncertain
        *
        * \return the maximal thickness of this tube
        */
       double max_diam() const;
 
       /**
-       * \brief Returns the diameter of the gate of this tube that is the more uncertain
+       * \brief Returns the diameter of the gate of this tube that is the most uncertain
        *
        * \param t the temporal key of the corresponding uncertain gate
        * \return the maximal thickness of the gate

--- a/src/core/dynamics/tube/tubex_TubeVector.cpp
+++ b/src/core/dynamics/tube/tubex_TubeVector.cpp
@@ -539,6 +539,50 @@ namespace tubex
       return thickness;
     }
 
+const double TubeVector::max_gate_diam(double & t) const
+  {
+    double max_gate_diam=0; 
+    for (int i = 0 ; i < size() ; i++){
+      double ti;
+      double gate_diam= (*this)[i].max_gate_diam(ti);
+      if (gate_diam > max_gate_diam){
+	t=ti;
+	max_gate_diam=gate_diam;
+      }
+    }
+    return max_gate_diam;
+  }	
+
+  const Slice* TubeVector::largest_slice() const{
+    const Slice* s;
+    
+    double max_diam=0;
+    for (int k=0; k< size() ; k++){
+      const Slice*  s0= (*this)[k].largest_slice();
+      if (s0->codomain().diam() >= max_diam){
+	s=s0;
+	max_diam=s0->codomain().diam();
+      }
+    }
+    return s;
+  }
+    
+ 
+ const Slice* TubeVector::steepest_slice() const{
+    const Slice* s;
+    double maxdif=0;
+       for (int k=0; k< size(); k++){
+	const Slice* s0= (*this)[k].steepest_slice();
+	double dif=fabs(s0->output_gate().mid()-s0->input_gate().mid());
+	if (dif >= maxdif) {s=s0;
+	 maxdif=dif;}
+      }
+
+       return s;
+ }
+    
+
+
     const TrajectoryVector TubeVector::diam(bool gates_thicknesses) const
     {
       TrajectoryVector thickness(size());

--- a/src/core/dynamics/tube/tubex_TubeVector.h
+++ b/src/core/dynamics/tube/tubex_TubeVector.h
@@ -453,6 +453,27 @@ namespace tubex
       const ibex::Vector max_diam() const;
 
       /**
+       * \brief Returns the maximum diameter of a gate of the tube vector in all components
+       *
+       * \return the maximal diameter of a gate of this tube and the instant in the variable t
+       */
+      const double max_gate_diam( double & t) const;
+
+      /**
+       * \brief Returns the slice of the tube of this tubevector with the largest codomain in all components
+       *
+       * \return the largest slice
+       */
+        const Slice* largest_slice() const;
+       
+/**
+       * \brief Returns the slice of the tube of this tubevector with the largest difference between input and output gates in all components
+       *
+       * \return the steepest slice
+       */
+        const Slice* steepest_slice() const;
+
+      /**
        * \brief Returns the diameters of the tube as a trajectory
        *
        * \note Without derivative knowledge, and because the tube is made of boxed slices,

--- a/src/core/functions/tubex_Fnc.cpp
+++ b/src/core/functions/tubex_Fnc.cpp
@@ -92,7 +92,7 @@ namespace tubex
           v_sy[i] = v_sy[i]->next_slice();
 
       res_codomain = eval_vector(v_sy[0]->domain(), x);
-      res_gate = eval_vector(v_sy[0]->domain().lb(), x);
+      res_gate = eval_vector(Interval(v_sy[0]->domain().lb()), x);
 
       for(int i = 0 ; i < y.size() ; i++)
       {
@@ -102,7 +102,7 @@ namespace tubex
 
     } while(v_sy[0]->next_slice() != NULL);
     
-    res_gate = eval_vector(v_sy[0]->domain().ub(), x);
+    res_gate = eval_vector(Interval(v_sy[0]->domain().ub()), x);
     for(int i = 0 ; i < y.size() ; i++)
       v_sy[i]->set_output_gate(res_gate[i], false);
 

--- a/src/core/graphics/tubex_ColorMap.cpp
+++ b/src/core/graphics/tubex_ColorMap.cpp
@@ -67,7 +67,7 @@ namespace tubex
   {
     assert(m_colormap.size() >= 2 && "color map defined by at least two colors");
 
-    if(isnan(r)) // undefined ratio
+    if(std::isnan(r)) // undefined ratio
       return make_rgb((float)0.5, 0.5, 0.5);
     assert(Interval(0.,1.).contains(r) && "r between 0 and 1");
 


### PR DESCRIPTION
new methods for choosing the slice to be refined in Tube and TubeVector
steepest_slice
the slice where the difference between the input and outout gate midvalue is the largest

adding methods  max_gate_diam and largest_slice for a TubeVector.

