### PR TITLE
new method "merge_similar_slices" for a Tube and improved computation time of CtcDelay

### DIFF
--- a/src/core/dynamics/tube/tubex_Tube.cpp
+++ b/src/core/dynamics/tube/tubex_Tube.cpp
@@ -1101,6 +1101,24 @@ namespace tubex
       Slice::merge_slices(s1, s2);
     }
 
+    void Tube::merge_similar_slices(double distance_threshold)
+    {
+      Slice *s2 = first_slice();
+      while(s2 != NULL)
+      {
+          Slice *s1 = s2->prev_slice();
+          Slice *next_slice = s2->next_slice();
+          if(s1 != NULL)
+          {
+              if(distance(s1->codomain(),s2->codomain()) < distance_threshold)
+              {
+                  Slice::merge_slices(s1, s2);
+              }
+          }
+          s2 = next_slice;
+      }
+    }
+
     // Bisection
     
     const pair<Tube,Tube> Tube::bisect(double t, float ratio) const

--- a/src/core/dynamics/tube/tubex_Tube.h
+++ b/src/core/dynamics/tube/tubex_Tube.h
@@ -781,6 +781,15 @@ namespace tubex
        */
       void remove_gate(double t);
 
+      /**
+       * \brief Merges all adjacent slices whose Hausdorff distance is less than the given threshold
+       *
+       * \note Adjacent slices whose Hausdorff distance is larger (or equal) than the given threshold are not merged
+       *
+       * \param distance_threshold the threshold for the maximum Haussdorf distance between adjacent slices
+       */
+      void merge_similar_slices(double distance_threshold);
+
       /// @}
       /// \name Bisection
       /// @{


### PR DESCRIPTION
Hey!

I added a new method `merge_similar_slices` in the Tube class which allows to merge all adjacent slices whose Hausdorff distance is less than the given threshold.

Besides, I improved the computation time of `CtcDelay` by checking if a costly tube inversion is necessary before doing it.

Best,
Raphael