### PR TITLE
[fix] Args section is empty in codac_py_XXX_docs headers

### DIFF
--- a/scripts/pybind/doxygen2docstring.py
+++ b/scripts/pybind/doxygen2docstring.py
@@ -213,7 +213,7 @@ for xml_doc in files:
 
         for param in params:
           param_name = param.find("declname")
-          if param_name:
+          if param_name != None and param_name.text:
             print(indent + param_name.text, "(" + get_tags_text(param.find("type")) + "): ", end='', file=f)
             parameterlist = memberdef.find("detaileddescription/para/parameterlist")
 


### PR DESCRIPTION
When doc files are generate, the "Args" section of docstring is empty.

For instance with the generated file "codac_py_Slice_docs.h", I got
```C++
// std::ostream& operator<<(std::ostream &str, const Slice &x)
const char* SLICE_OSTREAM_OPERATOR_OSTREAM_SLICE = R"_docs(Displays a synthesis of this slice.

Args:

Returns:
  ostream.
)_docs";
```
 instead of 
```C++
// std::ostream& operator<<(std::ostream &str, const Slice &x)
const char* SLICE_OSTREAM_OPERATOR_OSTREAM_SLICE = R"_docs(Displays a synthesis of this slice.

Args:
  str (ostream): ostream.
  x (Slice): slice to be displayed.

Returns:
  ostream.
)_docs";
 ```
