### PR TITLE
Adding two matrix operators: transpose and flatten.

### DIFF
--- a/python/src/core/operators/codac2_py_operators.cpp
+++ b/python/src/core/operators/codac2_py_operators.cpp
@@ -32,6 +32,7 @@
 #include "codac2_py_cross_prod_docs.h"
 #include "codac2_py_det_docs.h"
 #include "codac2_py_exp_docs.h"
+#include "codac2_py_flatten_docs.h"
 #include "codac2_py_floor_docs.h"
 #include "codac2_py_log_docs.h"
 #include "codac2_py_mat_docs.h"
@@ -47,6 +48,7 @@
 #include "codac2_py_subvector_docs.h"
 #include "codac2_py_tan_docs.h"
 #include "codac2_py_tanh_docs.h"
+#include "codac2_py_transpose_docs.h"
 #include "codac2_py_vec_docs.h"
 
 using namespace std;
@@ -410,6 +412,22 @@ void export_operators(py::module& m)
     SCALAREXPR_FLOOR_CONST_SCALAREXPR_REF,
     "x1"_a);
 
+  py::class_<FlattenOp>(m, "FlattenOp")
+    .def(py::init<>()) // for using static methods in Matlab
+    .def_static("fwd", (IntervalVector(*)(const IntervalMatrix&)) 
+		&FlattenOp::fwd,
+      STATIC_INTERVALVECTOR_FLATTENOP_FWD_CONST_INTERVALMATRIX_REF,
+      "x1"_a)
+    .def_static("bwd", (void(*)(const IntervalVector&,IntervalMatrix&))
+		 &FlattenOp::bwd,
+      STATIC_VOID_FLATTENOP_BWD_CONST_INTERVALVECTOR_REF_INTERVALMATRIX_REF, 
+      "y"_a, "x1"_a)
+  ;
+
+  m.def("flatten", [](const MatrixExpr& e1) { return flatten(e1); },
+    VECTOREXPR_FLATTEN_CONST_MATRIXEXPR_REF,
+    "x1"_a);
+
   py::class_<LogOp>(m, "LogOp")
     .def(py::init<>()) // for using static methods in Matlab
     .def_static("fwd", (Interval(*)(const Interval&)) &LogOp::fwd,
@@ -648,6 +666,22 @@ void export_operators(py::module& m)
 
   m.def("tanh", [](const ScalarExpr& e1) { return tanh(e1); },
     SCALAREXPR_TANH_CONST_SCALAREXPR_REF,
+    "x1"_a);
+
+  py::class_<TransposeOp>(m, "TransposeOp")
+    .def(py::init<>()) // for using static methods in Matlab
+    .def_static("fwd", (IntervalMatrix(*)(const IntervalMatrix&)) 
+		&TransposeOp::fwd,
+      STATIC_INTERVALMATRIX_TRANSPOSEOP_FWD_CONST_INTERVALMATRIX_REF,
+      "x1"_a)
+    .def_static("bwd", (void(*)(const IntervalMatrix&,IntervalMatrix&))
+		 &TransposeOp::bwd,
+      STATIC_VOID_TRANSPOSEOP_BWD_CONST_INTERVALMATRIX_REF_INTERVALMATRIX_REF,
+      "y"_a, "x1"_a)
+  ;
+
+  m.def("transpose", [](const MatrixExpr& e1) { return transpose(e1); },
+    MATRIXEXPR_TRANSPOSE_CONST_MATRIXEXPR_REF,
     "x1"_a);
 
   py::class_<VectorOp>(m, "VectorOp")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -114,6 +114,7 @@
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_cross_prod.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_det.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_exp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_flatten.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_floor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_log.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_mat.h
@@ -130,6 +131,7 @@
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_subvector.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_tan.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_tanh.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_transpose.h
     ${CMAKE_CURRENT_SOURCE_DIR}/operators/codac2_vec.h
 
     ${CMAKE_CURRENT_SOURCE_DIR}/matrices/eigen/Matrix_addons/codac2_Matrix_addons_Base.h

--- a/src/core/operators/codac2_flatten.h
+++ b/src/core/operators/codac2_flatten.h
@@ -1,0 +1,82 @@
+/** 
+ *  \file codac2_flatten.h
+ * ----------------------------------------------------------------------------
+ *  \date       2024
+ *  \author     Simon Rohou, Damien Massé
+ *  \copyright  Copyright 2024 Codac Team
+ *  \license    GNU Lesser General Public License (LGPL)
+ */
+
+#pragma once
+
+#include "codac2_Interval.h"
+#include "codac2_IntervalVector.h"
+#include "codac2_IntervalMatrix.h"
+#include "codac2_AnalyticType.h"
+
+namespace codac2
+{
+  struct FlattenOp
+  {
+    template<typename X1>
+    static std::string str(const X1& x1)
+    {
+      return "flatten(" + x1->str() + ")";
+    }
+
+    template<typename X1>
+    static std::pair<Index,Index> output_shape(const X1& s1)
+    {
+      auto shape1 = s1->output_shape();
+      return { shape1.second*shape1.first, 1 };
+    }
+
+    static IntervalVector fwd(const IntervalMatrix& x1);
+    static VectorType fwd_natural(const MatrixType& x1);
+    static VectorType fwd_centered(const MatrixType& x1);
+    static void bwd(const IntervalVector& y, IntervalMatrix& x1);
+  };
+
+  // Analytic operator
+  // The following functions can be used to build analytic expressions.
+
+  inline VectorExpr
+  flatten(const MatrixExpr &x1) 
+  {
+     return { std::make_shared<AnalyticOperationExpr<FlattenOp,VectorType,MatrixType>>(x1) };
+  }
+
+  // Inline functions
+
+    inline IntervalVector FlattenOp::fwd(const IntervalMatrix& x1)
+    {
+      return x1.reshaped();
+    }
+
+    inline VectorType FlattenOp::fwd_natural(const MatrixType& x1)
+    {
+      return {
+        fwd(x1.a),
+        x1.def_domain
+      };
+    }
+
+    inline VectorType FlattenOp::fwd_centered(const MatrixType& x1)
+    {
+      if(centered_form_not_available_for_args(x1))
+        return fwd_natural(x1);
+      
+      return {
+        fwd(x1.m),
+        fwd(x1.a),
+        x1.da,
+        x1.def_domain
+      };
+    }
+
+    inline void FlattenOp::bwd(const IntervalVector& y, IntervalMatrix& x1)
+    {
+      x1 &= y.reshaped(x1.rows(),x1.cols());
+    }
+
+}

--- a/src/core/operators/codac2_operators.h
+++ b/src/core/operators/codac2_operators.h
@@ -26,6 +26,7 @@
 #include "codac2_cross_prod.h"
 #include "codac2_det.h"
 #include "codac2_exp.h"
+#include "codac2_flatten.h"
 #include "codac2_floor.h"
 #include "codac2_log.h"
 #include "codac2_mat.h"
@@ -42,4 +43,5 @@
 #include "codac2_subvector.h"
 #include "codac2_tan.h"
 #include "codac2_tanh.h"
+#include "codac2_transpose.h"
 #include "codac2_vec.h"

--- a/src/core/operators/codac2_transpose.h
+++ b/src/core/operators/codac2_transpose.h
@@ -1,0 +1,89 @@
+/** 
+ *  \file codac2_transpose.h
+ * ----------------------------------------------------------------------------
+ *  \date       2024
+ *  \author     Simon Rohou, Damien Massé
+ *  \copyright  Copyright 2024 Codac Team
+ *  \license    GNU Lesser General Public License (LGPL)
+ */
+
+#pragma once
+
+#include "codac2_Interval.h"
+#include "codac2_IntervalVector.h"
+#include "codac2_IntervalMatrix.h"
+#include "codac2_AnalyticType.h"
+
+namespace codac2
+{
+  struct TransposeOp
+  {
+    template<typename X1>
+    static std::string str(const X1& x1)
+    {
+      return "transpose(" + x1->str() + ")";
+    }
+
+    template<typename X1>
+    static std::pair<Index,Index> output_shape(const X1& s1)
+    {
+      auto shape1 = s1->output_shape();
+      return { shape1.second, shape1.first };
+    }
+
+    static IntervalMatrix fwd(const IntervalMatrix& x1);
+    static MatrixType fwd_natural(const MatrixType& x1);
+    static MatrixType fwd_centered(const MatrixType& x1);
+    static void bwd(const IntervalMatrix& y, IntervalMatrix& x1);
+  };
+
+  // Analytic operator
+  // The following functions can be used to build analytic expressions.
+
+  inline MatrixExpr
+  transpose(const MatrixExpr &x1) 
+  {
+     return { std::make_shared<AnalyticOperationExpr<TransposeOp,MatrixType,MatrixType>>(x1) };
+  }
+
+  // Inline functions
+
+    inline IntervalMatrix TransposeOp::fwd(const IntervalMatrix& x1)
+    {
+      return x1.transpose();
+    }
+
+    inline MatrixType TransposeOp::fwd_natural(const MatrixType& x1)
+    {
+      return {
+        fwd(x1.a),
+        x1.def_domain
+      };
+    }
+
+    inline MatrixType TransposeOp::fwd_centered(const MatrixType& x1)
+    {
+      if(centered_form_not_available_for_args(x1))
+        return fwd_natural(x1);
+      
+      IntervalMatrix d(x1.da.rows(),x1.da.cols());
+      for (Index i=0; i<x1.a.rows(); i++)
+        for (Index j=0;j<x1.a.cols(); j++) {
+            /* x2.a(j,i) = x1.a(i,j) */
+         d.row(j+i*x1.a.cols()) = x1.da.row(i+j*x1.a.rows());
+      }
+
+      return {
+        fwd(x1.m),
+        fwd(x1.a),
+        d,
+        x1.def_domain
+      };
+    }
+
+    inline void TransposeOp::bwd(const IntervalMatrix& y, IntervalMatrix& x1)
+    {
+      x1 &= y.transpose();
+    }
+
+}

--- a/tests/core/functions/analytic/codac2_tests_AnalyticFunction.cpp
+++ b/tests/core/functions/analytic/codac2_tests_AnalyticFunction.cpp
@@ -492,4 +492,23 @@ TEST_CASE("AnalyticFunction")
 				  {{1.0,2.0},{-0.2,-0.1}}}) ),1e-9)
 		== Matrix({{0,0}, {0,0}}));
   }
+
+  {
+    MatrixVar m(2,2);
+    AnalyticFunction f({m}, m*transpose(m));
+    CHECK(f.output_shape()==std::pair<Index,Index>(2,2));
+    ScalarVar theta;
+    AnalyticFunction g({theta}, flatten(f(mat(vec(cos(theta),sin(theta)),
+				vec(-sin(theta),cos(theta))))));
+    Interval a = Interval(0.3,0.4);
+    Interval v1 = cos(a)*cos(a)+sin(a)*sin(a);
+    Interval v2 = cos(a)*sin(a)-cos(a)*sin(a);
+    CHECK(Approx(g.eval(EvalMode::NATURAL,a),1e-9)==
+		IntervalVector({ v1,v2,v2,v1 }));
+    Interval v3 = 1.0 + 2*(cos(a)*sin(a)-cos(a)*sin(a))*(a-a.mid());
+    Interval v4 = (cos(a)*cos(a)-cos(a)*cos(a)+sin(a)*sin(a)-sin(a)*sin(a))
+		*(a-a.mid());
+    CHECK(Approx(g.eval(EvalMode::CENTERED,a),1e-9) ==
+		IntervalVector({ v3,v4,v4,v3 }));
+  }
 }

--- a/tests/core/functions/analytic/codac2_tests_AnalyticFunction.py
+++ b/tests/core/functions/analytic/codac2_tests_AnalyticFunction.py
@@ -415,5 +415,20 @@ class TestAnalyticFunction(unittest.TestCase):
 					[[1.0,2.0],[-0.2,-0.1]]])),1e-9)
 			== Matrix([[0,0],[0,0]]))
 
+    m = MatrixVar(2,2)
+    f = AnalyticFunction([m], m*transpose(m))
+    theta = ScalarVar()
+    g = AnalyticFunction([theta], flatten(f(mat(vec(cos(theta),sin(theta)),
+                                                vec(-sin(theta),cos(theta))))))
+    a = Interval(0.3,0.4)
+    v1 = cos(a)*cos(a)+sin(a)*sin(a)
+    v2 = cos(a)*sin(a)-cos(a)*sin(a)
+    self.assertTrue(Approx(g.eval(EvalMode.NATURAL,a),1e-9)==
+                    IntervalVector([v1,v2,v2,v1]))
+    v3 = 1.0 + Interval(-2,2)*(cos(a)*sin(a)-cos(a)*sin(a))*a.rad()
+    v4 = (cos(a)*cos(a)-cos(a)*cos(a)+sin(a)*sin(a)-sin(a)*sin(a))*a.rad()
+    self.assertTrue(Approx(g.eval(EvalMode.CENTERED,a),1e-9)==
+                    IntervalVector([v3,v4,v4,v3]))
+
 if __name__ ==  '__main__':
   unittest.main()

--- a/tests/core/operators/codac2_tests_operators.cpp
+++ b/tests/core/operators/codac2_tests_operators.cpp
@@ -399,3 +399,23 @@ TEST_CASE("test mat operator")
   CHECK(MatrixOp::fwd(x1,x2,x3) == IntervalMatrix({{2,4,6},{3,5,7}}));
   CHECK(MatrixOp::fwd(x1) == IntervalMatrix({{2},{3}}));
 }
+
+TEST_CASE("test transpose operator")
+{
+  IntervalMatrix M({{ {1,1.5},{2,2.5},{3,3.5} },{ {4,4.5},{5,5.5},{6,6.5} } });
+  IntervalMatrix N({{ {0.8,1.2}, {3.5,4} }, { {2.0,2.2}, {4.8,5.2} },
+		{ {2.8,3.2}, {5.8,6.2} }});
+  CHECK(TransposeOp::fwd(M) == IntervalMatrix({{{1,1.5},{4,4.5}},{{2,2.5},{5,5.5}},{{3,3.5},{6,6.5}}}));
+  TransposeOp::bwd(N,M);
+  CHECK(M == IntervalMatrix({{ {1,1.2},{2,2.2},{3,3.2} },{ 4.0,{5,5.2},{6,6.2} } }));
+}
+
+TEST_CASE("test flatten operator")
+{
+  IntervalMatrix M({{ {1,1.5},{2,2.5},{3,3.5} },{ {4,4.5},{5,5.5},{6,6.5} } });
+  IntervalVector N({ {0.8,1.2}, {3.5,4} ,  {2.0,2.2}, {4.8,5.2} ,
+		 {2.8,3.2}, {5.8,6.2} });
+  CHECK(FlattenOp::fwd(M) == IntervalVector({{1,1.5},{4,4.5},{2,2.5},{5,5.5},{3,3.5},{6,6.5}}));
+  FlattenOp::bwd(N,M);
+  CHECK(M == IntervalMatrix({ {{1,1.2},{2,2.2},{3,3.2}} , {4.0,{5,5.2},{6,6.2}} }));
+}

--- a/tests/core/operators/codac2_tests_operators.py
+++ b/tests/core/operators/codac2_tests_operators.py
@@ -343,6 +343,23 @@ class TestInterval_bwd(unittest.TestCase):
     x1,x2,x3 = IntervalVector([2,3]), IntervalVector([4,5]), IntervalVector([6,7]) 
     self.assertTrue(MatrixOp.fwd(x1,x2,x3) == IntervalMatrix([[2,4,6],[3,5,7]]))
     self.assertTrue(MatrixOp.fwd(x1) == IntervalMatrix([[2],[3]]))
+
+  def tests_transpose_operator(self):
+    M = IntervalMatrix([[[1,1.5],[2,2.5],[3,3.5]],[[4,4.5],[5,5.5],[6,6.5]]])
+    N = IntervalMatrix([[[0.8,1.2],[3.5,4]],[[2.0,2.2],[4.8,5.2]],
+                        [[2.8,3.2],[5.8,6.2]]])
+    self.assertTrue(TransposeOp.fwd(M)==M.transpose())
+    TransposeOp.bwd(N,M)
+    self.assertTrue(M == IntervalMatrix([[[1,1.2],[2,2.2],[3,3.2]],[4.0,[5,5.2],[6,6.2]]]))
+
+  def tests_flatten_operator(self):
+    M = IntervalMatrix([[[1,1.5],[2,2.5],[3,3.5]],[[4,4.5],[5,5.5],[6,6.5]]])
+    N = IntervalVector([[0.8,1.2],[3.5,4],[2.0,2.2],[4.8,5.2],
+                        [2.8,3.2],[5.8,6.2]])
+    self.assertTrue(FlattenOp.fwd(M)==IntervalVector([[1,1.5],[4,4.5],[2,2.5],[5,5.5],[3,3.5],[6,6.5]]))
+    FlattenOp.bwd(N,M)
+    self.assertTrue(M == IntervalMatrix([[[1,1.2],[2,2.2],[3,3.2]],[4.0,[5,5.2],[6,6.2]]]))
+
   
 if __name__ ==  '__main__':
   unittest.main()


### PR DESCRIPTION
Proposition for two operators on matrix expressions:
- TransposeOp for the transpose of a matrix
- FlattenOp for the reshaping of a matrix to a vector (column-major, i.e. the default storage order of eigen).