### PR TITLE
Adding draw_zonotope, 2D and 3D + examples.

### DIFF
--- a/doc/manual/manual/visualization/3d_visualization.rst
+++ b/doc/manual/manual/visualization/3d_visualization.rst
@@ -3,7 +3,7 @@
 The 3D Figure class
 ===================
 
-  Main author: `Maël Godard <https://godardma.github.io>`_
+  Main author: `Maël Godard <https://godardma.github.io>`_, `Damien Massé <https://labsticc.fr/fr/annuaire/masse-damien>`_
 
 This page describes the class used in Codac for 3D visualization.
 
@@ -32,13 +32,24 @@ Drawing functions
 Below are the detailled available drawing functions. The shapes that can be drawn are:
 
 Geometric shapes
+  - Triangle
+  - Parallelogram
+  - Star-shaped polygon
   - Box
   - Parallelepiped
+  - Zonotope
+  - Arrow
+  - Parametric surface
+  - Sphere
 
 Paving
   - PavingOut (Paving with contractors)
   - PavingInOut (Paving with separators)
   - Subpaving
+
+Vehicles
+  - Car
+  - Plane
 
 In addition, a function ``draw_axes`` is available to draw the three axes of the 3D space.
 
@@ -50,10 +61,37 @@ Note that only the stroke color is used in all of the supported drawing function
 Geometric shapes
 ----------------
 
+.. doxygenfunction:: codac2::Figure3D::draw_triangle(const Vector&, const Matrix&, const Vector&, const Vector&, const Vector&, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure3D::draw_triangle(const Vector&, const Matrix&, const Vector&, const Vector&, const Vector&, const StyleProperties&)
+  :project: codac
+
+The ``draw_polygon`` can be used to draw a `star-shaped polygon <https://en.wikipedia.org/wiki/Star-shaped_polygon>`_ when the vectors are coplanar, and more
+generally a sequence of adjacent triangles sharing a same vertex.
+
+.. doxygenfunction:: codac2::Figure3D::draw_polygon(const Vector&, const Matrix&, const std::vector<Vector>&, const StyleProperties&)
+  :project: codac
+
 .. doxygenfunction:: codac2::Figure3D::draw_box(const IntervalVector&, const StyleProperties&)
   :project: codac
 
+.. doxygenfunction:: codac2::Figure3D::draw_parallelogram(const Vector&, const Matrix&, const Vector&, const Vector&, const Vector&, const StyleProperties&)
+  :project: codac
+
 .. doxygenfunction:: codac2::Figure3D::draw_parallelepiped(const Vector&, const Matrix&, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure3D::draw_zonotope(const Vector&, const std::vector<Vector>&, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure3D::draw_arrow(const Vector&, const Matrix& A, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure3D::draw_surface(const Vector&, const Matrix& , const Interval&, double, const Interval&, double, std::function<Vector(double,double)>, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure3D::draw_sphere(const Vector&, const Matrix& , const StyleProperties&)
   :project: codac
 
 Paving
@@ -67,3 +105,13 @@ Paving
 
 .. doxygenfunction:: codac2::Figure3D::draw_subpaving(const Subpaving<P>&, const StyleProperties&)
   :project: codac
+
+Vehicles
+--------
+
+.. doxygenfunction:: codac2::Figure3D::draw_car(const Vector&, const Matrix&, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure3D::draw_plane(const Vector&, const Matrix&, bool, const StyleProperties&)
+  :project: codac
+

--- a/doc/manual/manual/visualization/functions.rst
+++ b/doc/manual/manual/visualization/functions.rst
@@ -64,6 +64,7 @@ Geometric shapes
   - Polyline
   - Polygone
   - Parallelepiped
+  - Zonotope
   - Pie
   - Ellipse
   - Ellipsoid
@@ -116,6 +117,9 @@ Geometric shapes
   :project: codac
 
 .. doxygenfunction:: codac2::Figure2D::draw_parallelepiped(const Vector&, const Matrix&, const StyleProperties&)
+  :project: codac
+
+.. doxygenfunction:: codac2::Figure2D::draw_zonotope(const Vector&, const std::vector<Vector>&, const StyleProperties&)
   :project: codac
 
 .. doxygenfunction:: codac2::Figure2D::draw_pie(const Vector&, const Interval&, const Interval&, const StyleProperties&)

--- a/examples/00_graphics/graphic_examples.cpp
+++ b/examples/00_graphics/graphic_examples.cpp
@@ -55,6 +55,11 @@ int main(){
   fig2->draw_arrow({3,1},{2.2,2}, 0.2, {Color::red(),Color::black(0.3)});
   fig2->draw_parallelepiped({1.5,2.8},Matrix({{0.5,0.4},{0,0.2}}), {Color::red(),Color::green(0.5)});
 
+  fig2->draw_zonotope({4,1.5},
+		{{-0.2,0.1},{-0.06,0.04},{0.2,0.04},
+		 {0.06,-0.04},{0.01,-0.03},{0.08,0.18},{0,0}},
+	{{Color::red(),Color::yellow(0.4)},"zonotope"});
+
   // Colors
   // predefined colors without and with opacity
   fig2->draw_point({2,2}, {Color::red(),Color::yellow(0.5)});

--- a/examples/00_graphics/graphic_examples.py
+++ b/examples/00_graphics/graphic_examples.py
@@ -48,6 +48,9 @@ fig2.draw_ellipse([1,1],[0.5,2], 0.2, [Color.blue(),Color.blue(0.3)])
 fig2.draw_line([1,1],[3,3], Color.blue())
 fig2.draw_arrow([3,1],[2.2,2], 0.2, [Color.red(),Color.black(0.3)])
 fig2.draw_parallelepiped([1.5,2.8],Matrix([[0.5,0.4],[0,0.2]]), [Color.red(),Color.green(0.5)])
+fig2.draw_zonotope([4,1.5],[[-0.2,0.1],[-0.06,0.04],[0.2,0.04],
+                 [0.06,-0.04],[0.01,-0.03],[0.08,0.18],[0,0]],
+                StyleProperties([Color.red(),Color.yellow(0.4)],"zonotope"))
 
 # Colors
 # predefined colors without and with opacity

--- a/examples/06_graphics_3D/main.cpp
+++ b/examples/06_graphics_3D/main.cpp
@@ -51,6 +51,16 @@ int main()
   fig_examples.draw_plane({3,0,0},0.5*Matrix::Identity(3,3),true,
 		{ Color::dark_gray(0.8), "plane" });
 
+  fig_examples.draw_zonotope({1.5,1.5,1.5},
+	{{0.3,0.2,0.4},{-0.2,0.1,0.3},{-0.2,-0.1,0.0},{0.3,0.0,-0.1},
+         {-0.1,0.05,0.2},{0.0,0.2,0.1}}, 
+	{ Color::dark_green(1.0), "zonotope" });
+  fig_examples.draw_zonotope({-1.5,-1.5,-1.5},
+	{{0.3,0.2,0.0},{-0.2,0.1,0.0},{-0.2,-0.1,0.0},{0.3,0.0,0.0},
+         {-0.2,0.0,0.0},{-0.1,0.05,0.0},{0.0,0.2,0.0},{0.0,0.0,0.1}}, 
+	{ Color::dark_green(1.0), "zonotope2" });
+
+
   fig_examples.draw_surface({0,-2,0}, 0.5*Matrix::Identity(3,3), Interval(0,2*PI),
 		0.05*PI, Interval(0,2*PI), 0.05*PI,
 		[](double phi,double psi) -> Vector

--- a/examples/06_graphics_3D/main.py
+++ b/examples/06_graphics_3D/main.py
@@ -35,6 +35,15 @@ fig_examples.draw_car([-1,0,0],0.3*Matrix.eye(3,3),
 fig_examples.draw_plane([3,0,0],0.5*Matrix.eye(3,3),True,
                         StyleProperties(Color.dark_gray(0.8),"plane"))
 
+fig_examples.draw_zonotope([1.5,1.5,1.5],
+            [[0.3,0.2,0.4],[-0.2,0.1,0.3],[-0.2,-0.1,0.0],[0.3,0.0,-0.1],
+             [-0.1,0.05,0.2],[0.0,0.2,0.1]],
+                StyleProperties(Color.dark_green(1.0),"zonotope"))
+fig_examples.draw_zonotope([-1.5,-1.5,-1.5],
+        [[0.3,0.2,0.0],[-0.2,0.1,0.0],[-0.2,-0.1,0.0],[0.3,0.0,0.0],
+         [-0.2,0.0,0.0],[-0.1,0.05,0.0],[0.0,0.2,0.0],[0.0,0.0,0.1]], 
+                StyleProperties(Color.dark_green(1.0),"zonotope2"))
+
 def f(phi,psi):
     return Vector([(1-math.cos(phi))*math.sin(phi),
                    (1-math.cos(2*phi))*math.cos(phi)*math.cos(psi),

--- a/examples/07_centered_2D/CMakeLists.txt
+++ b/examples/07_centered_2D/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ==================================================================
+#  codac / basics example - cmake configuration file
+# ==================================================================
+
+  cmake_minimum_required(VERSION 3.5)
+  project(codac_example LANGUAGES CXX)
+
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Adding Codac
+
+  # In case you installed Codac in a local directory, you need 
+  # to specify its path with the CMAKE_PREFIX_PATH option.
+  # set(CMAKE_PREFIX_PATH "~/codac/build_install")
+
+  find_package(CODAC REQUIRED)
+  message(STATUS "Found Codac version ${CODAC_VERSION}")
+
+# Initializating Ibex
+  
+  ibex_init_common()
+
+# Compilation
+
+  if(FAST_RELEASE)
+    add_compile_definitions(FAST_RELEASE)
+    message(STATUS "You are running Codac in fast release mode. (option -DCMAKE_BUILD_TYPE=Release is required)")
+  endif()
+
+  add_executable(${PROJECT_NAME} main.cpp)
+  target_compile_options(${PROJECT_NAME} PUBLIC ${CODAC_CXX_FLAGS})
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${CODAC_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${CODAC_LIBRARIES})

--- a/examples/07_centered_2D/main.cpp
+++ b/examples/07_centered_2D/main.cpp
@@ -1,0 +1,46 @@
+#include <codac>
+
+using namespace std;
+using namespace codac2;
+
+int main(){
+
+  // Representation of centered form using zonotopes
+  Figure2D fig4 ("SpiralCentered",GraphicOutput::VIBES|GraphicOutput::IPE);
+
+  fig4.set_window_properties({500,50},{500,500});
+  fig4.set_axes(axis(0,{-10,10}), axis(1,{-10,10}));
+
+  double a=0.5;
+
+  ScalarVar t;
+  // we use Fermat's spiral
+  AnalyticFunction f1 ({t},{a*sqrt(t)*cos(t),a*sqrt(t)*sin(t)});
+
+  double dt=0.2;
+  double time=0.0;
+  while (time<100.0) {
+     Interval T(time,time+dt);
+     // using eval_<true> would be easier, but it's not allowed :(
+     IntervalVector df = f1.diff(T);
+     if (df.is_empty() || df.is_unbounded()) {
+		 /* not differentiable, we use a box */
+       IntervalVector bx = f1.eval(T);
+       fig4.draw_box(bx,{Color::blue(),Color::yellow(0.1)});
+     } else {
+       IntervalVector cent = f1.eval(T.mid());
+     // f(t) \in cent + df (t-T.mid())
+     //      \in cent.mid + [-1,1] * T.rad*df.mid + [-1,1]*cent.rad + 
+     //        [-1,1] * T.rad*df.rad
+       Vector inflationbox = cent.rad() + T.rad()*df.rad();
+       std::vector<Vector> v
+  	{ (T.rad()*df.mid()),
+	  { inflationbox[0], 0.0 }, { 0.0, inflationbox[1] } };
+       fig4.draw_zonotope(cent.mid(),v,{Color::red(),Color::yellow(0.1)});
+     }
+     time = time+dt;
+  }
+  
+  AnalyticTraj traj4 (f1,{0,100});
+  fig4.draw_trajectory(traj4,Color::black());
+}

--- a/examples/08_centered_3D/CMakeLists.txt
+++ b/examples/08_centered_3D/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ==================================================================
+#  codac / basics example - cmake configuration file
+# ==================================================================
+
+  cmake_minimum_required(VERSION 3.5)
+  project(codac_example LANGUAGES CXX)
+
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Adding Codac
+
+  # In case you installed Codac in a local directory, you need 
+  # to specify its path with the CMAKE_PREFIX_PATH option.
+  # set(CMAKE_PREFIX_PATH "~/codac/build_install")
+
+  find_package(CODAC REQUIRED)
+  message(STATUS "Found Codac version ${CODAC_VERSION}")
+
+# Initializating Ibex
+  
+  ibex_init_common()
+
+# Compilation
+
+  if(FAST_RELEASE)
+    add_compile_definitions(FAST_RELEASE)
+    message(STATUS "You are running Codac in fast release mode. (option -DCMAKE_BUILD_TYPE=Release is required)")
+  endif()
+
+  add_executable(${PROJECT_NAME} main.cpp)
+  target_compile_options(${PROJECT_NAME} PUBLIC ${CODAC_CXX_FLAGS})
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${CODAC_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${CODAC_LIBRARIES})

--- a/examples/08_centered_3D/main.cpp
+++ b/examples/08_centered_3D/main.cpp
@@ -1,0 +1,63 @@
+// The generated .obj files can be visualized on https://3dviewer.net
+
+#include <codac>
+
+using namespace std;
+using namespace codac2;
+
+int main()
+{
+  VectorVar x(2);
+
+  Figure3D fig_zon("zonotopes");
+  fig_zon.draw_axes(1.0);
+
+  AnalyticFunction f { {x},
+    {
+          (2.0+cos(x[0])/(1+(sin(x[0])^2.0)))*sin(x[1]),
+          (2.0+cos(x[0])/(1+(sin(x[0])^2.0)))*cos(x[1]),
+          2.0*sin(x[0])*cos(x[0])/(1+(sin(x[0])^2.0))
+          
+    }
+  };
+  
+  double phi=0.0;
+  double psi=0.0;
+  double dphi=0.3;
+  double dpsi=0.3;
+
+  while (phi<2*PI) {
+      psi=0.0;
+      while (psi<2*PI) {
+        IntervalVector T { {phi,phi+dphi}, {psi,psi+dpsi} };
+        IntervalMatrix df = f.diff(T);
+        if (df.is_empty() || df.is_unbounded()) {
+           IntervalVector bx = f.eval(T);
+           fig_zon.draw_box(bx, Color::blue(0.3)); 
+        } else {
+           IntervalVector cent = f.eval(T.mid());
+	   Vector inflationbox = cent.rad() + df.rad()*T.rad();
+           std::vector<Vector> v
+              { (T[0].rad()*df.col(0).mid()), (T[1].rad()*df.col(1).mid()),
+              { inflationbox[0], 0.0, 0.0 }, { 0.0, inflationbox[1], 0.0 },
+	      { 0.0, 0.0, inflationbox[2] } };
+           fig_zon.draw_zonotope(cent.mid(),v,Color::red(0.3));
+        }
+        psi=psi+dpsi;
+      }
+      phi=phi+dphi;
+  }
+
+  fig_zon.draw_surface({0,0,0}, Matrix::Identity(3,3),
+		 Interval(0,2*PI),
+		0.05*PI, Interval(0,2*PI), 0.05*PI,
+		[](double phi,double psi) -> Vector
+    { return {
+          (2.0+cos(phi)/(1+(sin(phi)*sin(phi))))*sin(psi),
+          (2.0+cos(phi)/(1+(sin(phi)*sin(phi))))*cos(psi),
+          2.0*sin(phi)*cos(phi)/(1+(sin(phi)*sin(phi)))
+      }; 
+    } ,
+		{ Color::green(0.6), "surface" });
+  
+}

--- a/python/src/graphics/figures/codac2_py_Figure2D.cpp
+++ b/python/src/graphics/figures/codac2_py_Figure2D.cpp
@@ -163,6 +163,10 @@ void export_Figure2D(py::module& m)
       VOID_FIGURE2D_DRAW_PARALLELEPIPED_CONST_VECTOR_REF_CONST_MATRIX_REF_CONST_STYLEPROPERTIES_REF,
       "z"_a, "A"_a, "s"_a=StyleProperties())
 
+    .def("draw_zonotope", &Figure2D::draw_zonotope,
+	VOID_FIGURE2D_DRAW_ZONOTOPE_CONST_VECTOR_REF_CONST_VECTOR_VECTOR_REF_CONST_STYLEPROPERTIES_REF,
+      "z"_a, "A"_a, "s"_a=StyleProperties())
+
     .def("draw_pie", &Figure2D::draw_pie,
       VOID_FIGURE2D_DRAW_PIE_CONST_VECTOR_REF_CONST_INTERVAL_REF_CONST_INTERVAL_REF_CONST_STYLEPROPERTIES_REF,
       "c"_a, "r"_a, "theta"_a, "s"_a=StyleProperties())

--- a/python/src/graphics/figures/codac2_py_Figure3D.cpp
+++ b/python/src/graphics/figures/codac2_py_Figure3D.cpp
@@ -80,6 +80,10 @@ void export_Figure3D(py::module& m)
       VOID_FIGURE3D_DRAW_SPHERE_CONST_VECTOR_REF_CONST_MATRIX_REF_CONST_STYLEPROPERTIES_REF,
       "c"_a, "A"_a, "s"_a=StyleProperties(Color::blue(0.5)))
     
+    .def("draw_ellipsoid", &Figure3D::draw_ellipsoid,
+       VOID_FIGURE3D_DRAW_ELLIPSOID_CONST_ELLIPSOID_REF_CONST_STYLEPROPERTIES_REF,
+      "e"_a, "s"_a=StyleProperties(Color::blue(0.5)))
+
     .def("draw_car", &Figure3D::draw_car,
       VOID_FIGURE3D_DRAW_CAR_CONST_VECTOR_REF_CONST_MATRIX_REF_CONST_STYLEPROPERTIES_REF,
       "c"_a, "A"_a, "s"_a=StyleProperties(Color::yellow(0.5)))

--- a/python/src/graphics/figures/codac2_py_Figure3D.cpp
+++ b/python/src/graphics/figures/codac2_py_Figure3D.cpp
@@ -64,6 +64,10 @@ void export_Figure3D(py::module& m)
       VOID_FIGURE3D_DRAW_PARALLELEPIPED_CONST_VECTOR_REF_CONST_MATRIX_REF_CONST_STYLEPROPERTIES_REF,
       "z"_a, "A"_a, "s"_a=StyleProperties())
 
+    .def("draw_zonotope", &Figure3D::draw_zonotope,
+      VOID_FIGURE3D_DRAW_ZONOTOPE_CONST_VECTOR_REF_CONST_VECTOR_VECTOR_REF_CONST_STYLEPROPERTIES_REF, 
+      "z"_a, "A"_a, "s"_a=StyleProperties())
+
     .def("draw_arrow", &Figure3D::draw_arrow,
       VOID_FIGURE3D_DRAW_ARROW_CONST_VECTOR_REF_CONST_MATRIX_REF_CONST_STYLEPROPERTIES_REF,
       "c"_a, "A"_a, "s"_a=StyleProperties())

--- a/src/graphics/figures/codac2_Figure2D.cpp
+++ b/src/graphics/figures/codac2_Figure2D.cpp
@@ -231,7 +231,7 @@ void Figure2D::draw_zonotope(const Vector& z, const std::vector<Vector>& A, cons
        if (u==Vector::zero(2)) continue;
        double theta = std::atan2(u[1],u[0]);
        Vector v(u);
-       if (theta<=0.0) { theta=theta+M_PI; v=-v; } 
+       if (theta<=0.0) { theta=theta+PI; v=-v; } 
 		/* theta in ]0,PI] , v[1]>=0 and if v[1]=0, v[0]<0 */
        auto try_insert=sides.insert({theta,v});
        if (try_insert.second==false) {

--- a/src/graphics/figures/codac2_Figure2D.h
+++ b/src/graphics/figures/codac2_Figure2D.h
@@ -288,6 +288,15 @@ namespace codac2
       void draw_parallelepiped(const Vector& z, const Matrix& A, const StyleProperties& s = StyleProperties());
 
       /**
+       * \brief Draws a zonotope z+A*[-1,1]^2 on the figure
+       * 
+       * \param z Coordinates of the center of the zonotope
+       * \param A list of vectors (more consistant than matrix)
+       * \param s Style of the zonotope (edge color and fill color)
+       */
+      void draw_zonotope(const Vector& z, const std::vector<Vector>& A, const StyleProperties& s = StyleProperties());
+
+      /**
        * \brief Draws a pie on the figure
        * 
        * \param c Center of the pie

--- a/src/graphics/figures/codac2_Figure2D.h
+++ b/src/graphics/figures/codac2_Figure2D.h
@@ -288,10 +288,10 @@ namespace codac2
       void draw_parallelepiped(const Vector& z, const Matrix& A, const StyleProperties& s = StyleProperties());
 
       /**
-       * \brief Draws a zonotope z+A*[-1,1]^2 on the figure
+       * \brief Draws a zonotope z+sum_i [-1,1] A_i on the figure
        * 
        * \param z Coordinates of the center of the zonotope
-       * \param A list of vectors (more consistant than matrix)
+       * \param A list of vectors
        * \param s Style of the zonotope (edge color and fill color)
        */
       void draw_zonotope(const Vector& z, const std::vector<Vector>& A, const StyleProperties& s = StyleProperties());

--- a/src/graphics/figures/codac2_Figure3D.cpp
+++ b/src/graphics/figures/codac2_Figure3D.cpp
@@ -262,6 +262,10 @@ void Figure3D::draw_sphere(const Vector &c, const Matrix &A, const StyleProperti
   );
 }
 
+void Figure3D::draw_ellipsoid(const Ellipsoid &e, const StyleProperties& s) {
+  this->draw_sphere(e.mu, e.G,s);
+}
+
 void Figure3D::draw_car(const Vector &c, const Matrix &A,
                 const StyleProperties& s) {
   this->set_style_internal(s);

--- a/src/graphics/figures/codac2_Figure3D.h
+++ b/src/graphics/figures/codac2_Figure3D.h
@@ -18,7 +18,7 @@
 #include "codac2_Vector.h"
 #include "codac2_Matrix.h"
 #include "codac2_IntervalMatrix.h"
-
+#include "codac2_Ellipsoid.h"
 
 namespace codac2
 {
@@ -120,10 +120,10 @@ namespace codac2
       void draw_parallelepiped(const Vector& z, const Matrix& A, const StyleProperties& s = { Color::dark_gray(0.5) });
 
       /**
-       * \brief Draws a zonotope z+A*[-1,1]^2 on the figure
+       * \brief Draws a zonotope z+sum_i [-1,1] A_i on the figure
        * 
        * \param z Coordinates of the center of the zonotope
-       * \param A list of vectors (more consistant than matrix)
+       * \param A list of vectors 
        * \param s Style of the zonotope (edge color)
        */
       void draw_zonotope(const Vector& z, const std::vector<Vector>& A, const StyleProperties& s = { Color::dark_gray(0.5) });
@@ -181,6 +181,15 @@ namespace codac2
        * \param s Style (color)
        */
       void draw_sphere(const Vector &c, const Matrix &A,
+		const StyleProperties& s = { Color::dark_gray(0.5) });
+
+      /**
+       * \brief Draws an ellipsoid (from the Ellipsoid class)
+       *
+       * \param e Ellipsoid to draw
+       * \param s Style (color)
+       */
+      void draw_ellipsoid(const Ellipsoid &e,
 		const StyleProperties& s = { Color::dark_gray(0.5) });
 
       /** 

--- a/src/graphics/figures/codac2_Figure3D.h
+++ b/src/graphics/figures/codac2_Figure3D.h
@@ -120,12 +120,22 @@ namespace codac2
       void draw_parallelepiped(const Vector& z, const Matrix& A, const StyleProperties& s = { Color::dark_gray(0.5) });
 
       /**
+       * \brief Draws a zonotope z+A*[-1,1]^2 on the figure
+       * 
+       * \param z Coordinates of the center of the zonotope
+       * \param A list of vectors (more consistant than matrix)
+       * \param s Style of the zonotope (edge color)
+       */
+      void draw_zonotope(const Vector& z, const std::vector<Vector>& A, const StyleProperties& s = { Color::dark_gray(0.5) });
+
+      /**
        * \brief Draws a box on the figure
        * 
        * \param x Box to draw
        * \param s Style of the box (edge color)
        */      
       void draw_box(const IntervalVector& x, const StyleProperties& s = { Color::dark_gray(0.5) });
+
 
       /**
        * \brief Draws an arrow (box c + A * ([0,1],[-0.01,0.01],[-0.01,0.01]) and a


### PR DESCRIPTION
Adding draw_zonotope, 2D and 3D (c++ and python).
Two examples (07_centered_2D and 08_centered_3D, only C++) using centered form and (simple) zonotopes to enclose a curve or a surface.