### PR TITLE
Bugfix for IntFullPivLU::solve

### DIFF
--- a/src/core/matrices/codac2_IntvFullPivLU.cpp
+++ b/src/core/matrices/codac2_IntvFullPivLU.cpp
@@ -410,8 +410,9 @@ IntervalMatrix IntvFullPivLU::cokernel() const {
 IntervalMatrix IntvFullPivLU::solve(const IntervalMatrix &rhs) const {
     assert_release(rhs.rows()==matrixLU_.rows());
     IntervalMatrix prhs = _LU.permutationP()*rhs;
+    Index dim = std::min(matrixLU_.rows(),matrixLU_.cols());
     /* inverse L */
-    for (Index r = 0; r<matrixLU_.rows()-1; r++) {
+    for (Index r = 0; r<dim; r++) {
        for (Index r1=r+1;r1<matrixLU_.rows();r1++) {
           prhs.row(r1) -= matrixLU_(r1,r)*prhs.row(r);
        }
@@ -428,7 +429,6 @@ IntervalMatrix IntvFullPivLU::solve(const IntervalMatrix &rhs) const {
     }
     /* then use the diagonal elements */
     IntervalMatrix res = IntervalMatrix::Zero(matrixLU_.cols(),rhs.cols());
-    Index dim = std::min(matrixLU_.cols(),matrixLU_.rows());
     for (Index r = dim-1;r>=0;r--) {
         for (Index r1=r+1;r1<dim;r1++) {
            prhs.row(r) -= matrixLU_(r,r1)*res.row(r1);
@@ -450,8 +450,9 @@ IntervalMatrix IntvFullPivLU::solve(const IntervalMatrix &rhs) const {
 void IntvFullPivLU::solve(const IntervalMatrix &rhs, IntervalMatrix &B) const {
     assert_release(rhs.rows()==matrixLU_.rows() && B.rows()==matrixLU_.cols());
     IntervalMatrix prhs = _LU.permutationP()*rhs;
+    Index dim = std::min(matrixLU_.cols(),matrixLU_.rows());
     /* inverse L */
-    for (Index r = 0; r<matrixLU_.rows()-1; r++) {
+    for (Index r = 0; r<dim; r++) {
        for (Index r1=r+1;r1<matrixLU_.rows();r1++) {
           prhs.row(r1) -= matrixLU_(r1,r)*prhs.row(r);
        }
@@ -467,7 +468,6 @@ void IntvFullPivLU::solve(const IntervalMatrix &rhs, IntervalMatrix &B) const {
     IntervalMatrix qB = _LU.permutationQ().inverse()*B;
     /* then use the diagonal elements */
 //    IntervalMatrix res = IntervalMatrix::Zero(matrixLU_.cols(),rhs.cols());
-    Index dim = std::min(matrixLU_.cols(),matrixLU_.rows());
     IntervalMatrix U = matrixLU_.triangularView<Eigen::Upper>();
     for (Index r = dim-1;r>=0;r--) {
         IntervalRow rw=U.row(r);

--- a/tests/core/matrices/codac2_tests_IntFullPivLU.cpp
+++ b/tests/core/matrices/codac2_tests_IntFullPivLU.cpp
@@ -146,3 +146,68 @@ TEST_CASE("IntvFullPivLU")
   }
   
 }
+
+TEST_CASE("IntvFullPivLU solve tall matrix")
+{
+  Matrix A({
+    { 1, 0 },
+    { 0, 1 },
+    { 1, 1 },
+    { 2,-1 },
+    {-1, 2 },
+  });
+
+  Matrix X({
+    { 2,-1 },
+    {-1, 3 },
+  });
+
+  Matrix rhs_mid = A*X;
+  IntervalMatrix rhs(rhs_mid);
+
+  IntvFullPivLU lu(A);
+
+  SECTION("solve(rhs) with rows >= cols + 2")
+  {
+    IntervalMatrix sol = lu.solve(rhs);
+
+    CHECK(!sol.is_empty());
+    CHECK(sol.contains(X));
+    CHECK((A.template cast<Interval>() * sol).contains(rhs_mid));
+  }
+
+  SECTION("solve(rhs, B) with rows >= cols + 2")
+  {
+    IntervalMatrix B = IntervalMatrix::Constant(2,2,{-10.0,10.0});
+
+    lu.solve(rhs, B);
+
+    CHECK(!B.is_empty());
+    CHECK(B.contains(X));
+    CHECK((A.template cast<Interval>() * B).contains(rhs_mid));
+  }
+
+  SECTION("solve(rhs) detects inconsistent rhs")
+  {
+    Matrix rhs_bad_mid = rhs_mid;
+    rhs_bad_mid(4,0) += 1.0; // breaks consistency on the extra row
+
+    IntervalMatrix rhs_bad(rhs_bad_mid);
+    IntervalMatrix sol = lu.solve(rhs_bad);
+
+    CHECK(sol.is_empty());
+  }
+
+  SECTION("solve(rhs, B) detects inconsistent rhs")
+  {
+    Matrix rhs_bad_mid = rhs_mid;
+    rhs_bad_mid(4,0) += 1.0; // breaks consistency on the extra row
+
+    IntervalMatrix rhs_bad(rhs_bad_mid);
+    IntervalMatrix B = IntervalMatrix::Constant(2,2,{-10.0,10.0});
+
+    lu.solve(rhs_bad, B);
+
+    CHECK(B.is_empty());
+  }
+}

--- a/tests/core/matrices/codac2_tests_IntFullPivLU.py
+++ b/tests/core/matrices/codac2_tests_IntFullPivLU.py
@@ -13,72 +13,150 @@ from codac import *
 
 class TestIntvFullPivLU(unittest.TestCase):
 
+  def test_IntvFullPivLU_1(self):
+    M = Matrix([
+    [ 1, -4, 3, 7 ],
+    [ 2, 1, -4, 6 ],
+    [ 5, 2, 1 , 9 ],
+    [ -1, 0, 3, 2 ]
+    ])
 
-# bindings not implemented
-   def test_IntvFullPivLU_1(self):
-      M = Matrix([
-      [ 1, -4, 3, 7 ],
-      [ 2, 1, -4, 6 ],
-      [ 5, 2, 1 , 9 ],
-      [ -1, 0, 3, 2 ]
-      ])
+    LUdec = IntvFullPivLU(M)
+    self.assertTrue(LUdec.is_injective()==BoolInterval.TRUE)
+    self.assertTrue(LUdec.is_surjective()==BoolInterval.TRUE)
+    self.assertTrue(LUdec.rank()==Interval(4))
+    self.assertTrue((LUdec.determinant()+602).mag()<=1e-10)
+    self.assertTrue((LUdec.reconstructed_matrix()-M).norm().ub()<=1e-10)
+    I1 = LUdec.solve(IntervalMatrix.eye(4,4));
+    self.assertTrue((I1*M-Matrix.eye(4,4)).norm().ub()<1e-10)
 
-      LUdec = IntvFullPivLU(M)
-      self.assertTrue(LUdec.is_injective()==BoolInterval.TRUE)
-      self.assertTrue(LUdec.is_surjective()==BoolInterval.TRUE)
-      self.assertTrue(LUdec.rank()==Interval(4))
-      self.assertTrue((LUdec.determinant()+602).mag()<=1e-10)
-      self.assertTrue((LUdec.reconstructed_matrix()-M).norm().ub()<=1e-10)
-      I1 = LUdec.solve(IntervalMatrix.eye(4,4));
-      self.assertTrue((I1*M-Matrix.eye(4,4)).norm().ub()<1e-10)
+  def test_IntvFullPivLU_2(self):
+    M = Matrix([
+    [ 1, -4, 6, 7 ],
+    [ 2, 1, 3, 6 ],
+    [ 5, 2, 8 , 9 ],
+    [ -1, 0, -2, 2 ]
+    ])
 
-   def test_IntvFullPivLU_2(self):
-      M = Matrix([
-      [ 1, -4, 6, 7 ],
-      [ 2, 1, 3, 6 ],
-      [ 5, 2, 8 , 9 ],
-      [ -1, 0, -2, 2 ]
-      ])
+    LUdec = IntvFullPivLU(M)
+    self.assertTrue(LUdec.is_injective()==BoolInterval.UNKNOWN)
+    self.assertTrue(LUdec.is_surjective()==BoolInterval.UNKNOWN)
+    self.assertTrue(LUdec.rank()==Interval([3,4]))
+    self.assertTrue((LUdec.determinant()).mag()<=1e-10)
+    self.assertTrue((LUdec.reconstructed_matrix()-M).norm().ub()<=1e-10)
+    K = LUdec.kernel()
+    self.assertTrue(K.cols()==1)
+    self.assertTrue((M*K).norm().ub()<1e-10)
+    coK = LUdec.cokernel()
+    self.assertTrue(coK.rows()==1)
+    self.assertTrue((coK*M).norm().ub()<1e-10)
+    Im = LUdec.image(M)
+    self.assertTrue(Im.cols()==3)
+    coIm = LUdec.coimage(M)
+    self.assertTrue(coIm.rows()==3)
 
-      LUdec = IntvFullPivLU(M)
-      self.assertTrue(LUdec.is_injective()==BoolInterval.UNKNOWN)
-      self.assertTrue(LUdec.is_surjective()==BoolInterval.UNKNOWN)
-      self.assertTrue(LUdec.rank()==Interval([3,4]))
-      self.assertTrue((LUdec.determinant()).mag()<=1e-10)
-      self.assertTrue((LUdec.reconstructed_matrix()-M).norm().ub()<=1e-10)
-      K = LUdec.kernel()
-      self.assertTrue(K.cols()==1)
-      self.assertTrue((M*K).norm().ub()<1e-10)
-      coK = LUdec.cokernel()
-      self.assertTrue(coK.rows()==1)
-      self.assertTrue((coK*M).norm().ub()<1e-10)
-      Im = LUdec.image(M)
-      self.assertTrue(Im.cols()==3)
-      coIm = LUdec.coimage(M)
-      self.assertTrue(coIm.rows()==3)
+  def test_IntvFullPivLU_3(self):
+    M = Matrix([
+    [ 1, -4, 6, 7, 6 ],
+    [ 2, 1, 3, 6, -2 ],
+    [ 5, 2, 8 , 9, -1 ]
+    ])
+    LUdec = IntvFullPivLU(M)
+    self.assertTrue(LUdec.is_injective()==BoolInterval.FALSE)
+    self.assertTrue(LUdec.is_surjective()==BoolInterval.TRUE)
+    self.assertTrue(LUdec.rank()==Interval(3))
+    self.assertTrue((LUdec.reconstructed_matrix()-M).norm().ub()<=1e-10)
+    K = LUdec.kernel()
+    self.assertTrue(K.cols()==2)
+    self.assertTrue((M*K).norm().ub()<1e-10)
+    Im = LUdec.image(M)
+    self.assertTrue(Im.cols()==3)
+    I1 = LUdec.solve(IntervalMatrix.eye(3,3));
+    self.assertTrue((M*I1-Matrix.eye(3,3)).norm().ub()<1e-10)
+    A = IntervalMatrix([ [1], [[-20,20]], [2], [[-20,20]], [[-20,20]] ])
+    B = IntervalMatrix([ [2.0], [1.0], [4.0] ])
+    LUdec.solve(B,A)
+    self.assertTrue((M*A-B).norm().ub()<=1e-10)
 
-   def test_IntvFullPivLU_3(self):
-      M = Matrix([
-      [ 1, -4, 6, 7, 6 ],
-      [ 2, 1, 3, 6, -2 ],
-      [ 5, 2, 8 , 9, -1 ]
-      ])
-      LUdec = IntvFullPivLU(M)
-      self.assertTrue(LUdec.is_injective()==BoolInterval.FALSE)
-      self.assertTrue(LUdec.is_surjective()==BoolInterval.TRUE)
-      self.assertTrue(LUdec.rank()==Interval(3))
-      self.assertTrue((LUdec.reconstructed_matrix()-M).norm().ub()<=1e-10)
-      K = LUdec.kernel()
-      self.assertTrue(K.cols()==2)
-      self.assertTrue((M*K).norm().ub()<1e-10)
-      Im = LUdec.image(M)
-      self.assertTrue(Im.cols()==3)
-      I1 = LUdec.solve(IntervalMatrix.eye(3,3));
-      self.assertTrue((M*I1-Matrix.eye(3,3)).norm().ub()<1e-10)
-      A = IntervalMatrix([ [1], [[-20,20]], [2], [[-20,20]], [[-20,20]] ])
-      B = IntervalMatrix([ [2.0], [1.0], [4.0] ])
-      LUdec.solve(B,A)
-      self.assertTrue((M*A-B).norm().ub()<=1e-10)
+  def test_IntvFullPivLU_solve_tall_matrix(self):
 
+    A = Matrix([
+     [ 1, 0 ],
+     [ 0, 1 ],
+     [ 1, 1 ],
+     [ 2,-1 ],
+     [-1, 2 ],
+    ])
+ 
+    X = Matrix([
+     [ 2,-1 ],
+     [-1, 3 ],
+    ])
+ 
+    rhs_mid = A*X
+    rhs = IntervalMatrix(rhs_mid)
+ 
+    lu = IntvFullPivLU(A)
+ 
+    sol = lu.solve(rhs)
+ 
+    self.assertTrue(not sol.is_empty())
+    self.assertTrue(sol.contains(X))
+    self.assertTrue((A*sol).contains(rhs_mid))
+ 
+  def test_IntvFullPivLU_solve_tall_matrix_with_box(self):
+
+    A = Matrix([
+     [ 1, 0 ],
+     [ 0, 1 ],
+     [ 1, 1 ],
+     [ 2,-1 ],
+     [-1, 2 ],
+    ])
+ 
+    X = Matrix([
+     [ 2,-1 ],
+     [-1, 3 ],
+    ])
+ 
+    rhs_mid = A*X
+    rhs = IntervalMatrix(rhs_mid)
+ 
+    lu = IntvFullPivLU(A)
+    B = IntervalMatrix.constant(2,2,[-10,10])
+ 
+    lu.solve(rhs, B)
+ 
+    self.assertTrue(not B.is_empty())
+    self.assertTrue(B.contains(X))
+    self.assertTrue((A*B).contains(rhs_mid))
+
+  def test_IntvFullPivLU_solve_tall_matrix_inconsistent_rhs(self):
+
+    A = Matrix([
+     [ 1, 0 ],
+     [ 0, 1 ],
+     [ 1, 1 ],
+     [ 2,-1 ],
+     [-1, 2 ],
+    ])
+ 
+    rhs_bad = IntervalMatrix([
+      [[ 2, 2],[-1,-1]],
+      [[-1,-1],[ 3, 3]],
+      [[ 1, 1],[ 2, 2]],
+      [[ 5, 5],[-5,-5]],
+      [[-3,-3],[ 7, 7]], # should be [-4, 7] for consistency
+    ])
+ 
+    lu = IntvFullPivLU(A)
+ 
+    sol = lu.solve(rhs_bad)
+    self.assertTrue(sol.is_empty())
+ 
+    B = IntervalMatrix.constant(2,2,[-10,10])
+    lu.solve(rhs_bad, B)
+    self.assertTrue(B.is_empty())
+    
 if __name__ ==  '__main__':
   unittest.main()


### PR DESCRIPTION
Following bug report from Mael Godard (thanks Mael).
IntFullPivLU::solve crashed when the decomposition matrix had nb_rows > nb_cols+1.
